### PR TITLE
Ajuste no gatilho de workflow do GitHub Actions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,8 +1,6 @@
 name: PHP Composer
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
Remove o gatilho para push na branch "main", mantendo apenas o gatilho para pull requests. Isso simplifica o fluxo de trabalho e evita execuções desnecessárias.```